### PR TITLE
Support activating cljs repl

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '16'
           cache: 'npm'
       - run: npm install
       - run: npm test

--- a/README.md
+++ b/README.md
@@ -198,7 +198,9 @@ $ ./node_modules/.bin/cypress open
 
 ## Changelog
 
-* 0.1.7 
+* NEXT
+  * Support REPL
+* 0.1.7
   * Bump shadow-cljs to 2.14.5
   * Call process/exit to not leave zombies when Cypress exits
   * When adding a new test while the preprocessor is running

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ The shadow-cljs server is kept running while the Cypress runner is active. When 
 2. Install [Cypress](https://docs.cypress.io/guides/getting-started/installing-cypress.html#Installing)
 
    ```sh
-   $ npm install cypress --save-dev
+   npm install cypress --save-dev
    ```
 
 3. Install cypress-clojurescript-preprocessor
 
    ```sh
-   $ npm install cypress-clojurescript-preprocessor
+   npm install cypress-clojurescript-preprocessor
    ```
 
 4. Configure ClojureScript preprocessor
@@ -73,7 +73,7 @@ The shadow-cljs server is kept running while the Cypress runner is active. When 
 6. Run test
 
    ```sh
-   $ ./node_modules/.bin/cypress open
+   ./node_modules/.bin/cypress open
    ```
 
 ## REPL in Cypress

--- a/README.md
+++ b/README.md
@@ -76,6 +76,50 @@ The shadow-cljs server is kept running while the Cypress runner is active. When 
    $ ./node_modules/.bin/cypress open
    ```
 
+## REPL in Cypress
+
+You can active REPL into a test in the browser that Cypress is controlling.
+
+1. Lookup NREPL port used by the shadow-cljs server
+
+   ```
+   $ cat .preprocessor-cljs/.shadow-cljs/nrepl.port
+   50796
+   ```
+
+2. Connect to the NREPL server and start shadow-cljs watch
+
+   ```
+   shadow.user> (shadow/watch :window)
+   ```
+
+   The build-id is a keyword of the test file name
+
+3. Start a ClojureScript repl
+
+   ```
+   shadow.user> (shadow/repl :window)
+   To quit, type: :cljs/quit
+   [:selected :window]
+   cljs.user> (js/alert "plop") ;; To try out that it works
+   ```
+
+Now you can use the slightly undocumented `now` command to execute Cypress command immediately, for example, to select an option:
+
+```
+cljs.user> (-> (.now js/cy "get" "#some-opt")
+               (.then (fn [el]
+                        (.now js/cy "select" el "two"))))
+#object[Promise [object Promise]]
+```
+
+Some references to the `now` command:
+
+* https://github.com/cypress-io/cypress/issues/6080#issuecomment-570481923
+* https://docs.cypress.io/guides/guides/debugging#Run-Cypress-command-outside-the-test
+* https://github.com/cypress-io/cypress/issues/8195
+* https://github.com/cypress-io/cypress/issues/3636#issuecomment-511315778
+
 ## Configuration
 
 ### Shadow CLJS configuration override

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "chokidar": "3.5.2",
     "shadow-cljs": "2.14.5",
-    "@cypress/browserify-preprocessor": "3.0.1"
+    "@cypress/browserify-preprocessor": "3.0.1",
+    "signal-exit": "^3.0.3"
   },
   "scripts": {
     "prepare": "shadow-cljs release app",

--- a/src/net/tiuhti/cypress_cljs.cljs
+++ b/src/net/tiuhti/cypress_cljs.cljs
@@ -1,7 +1,6 @@
 (ns net.tiuhti.cypress-cljs
   (:require ["child_process" :as cp]
             ["fs" :as fs]
-            ["process" :as process]
             ["path" :as path]
             ["chokidar" :as chokidar]
             ["events" :as EventEmitter]

--- a/src/net/tiuhti/cypress_cljs.cljs
+++ b/src/net/tiuhti/cypress_cljs.cljs
@@ -10,13 +10,32 @@
             [clojure.string :as str]
             [cljs.pprint :refer [pprint]]
             [meta-merge.core :as m]
+            ["net" :as node-net]
             ["@cypress/browserify-preprocessor" :as browserify-preprocessor]))
+
+(def build-hook
+  "
+(ns watch
+  (:import (java.util.concurrent LinkedBlockingQueue)))
+
+(def flush-queue (LinkedBlockingQueue.))
+
+(defn hook
+  {:shadow.build/stage :flush}
+  [build-state]
+  (.put flush-queue (:shadow.build/build-id build-state))
+  build-state)
+")
 
 (def working-directory ".preprocessor-cljs")
 
 (def shadow-cljs-bin-path "../node_modules/.bin/shadow-cljs")
 
 (def config-path (str working-directory "/" "shadow-cljs.edn"))
+
+(def hook-path (str working-directory "/" "watch.clj"))
+
+(def cli-repl-port-path (str working-directory "/" ".shadow-cljs/cli-repl.port"))
 
 (def default-config
   {:dependencies [['mocha-latte "0.1.2"]
@@ -82,14 +101,15 @@
                                build-id   (keyword test-name)]
                            (assoc acc
                                   build-id
-                                  {:target     :browser
-                                   :output-dir output-dir
-                                   :asset-path (str "/" output-dir)
-                                   :modules    {build-id {:entries [entry]}}})))
+                                  {:target      :browser
+                                   :output-dir  output-dir
+                                   :asset-path  (str "/" output-dir)
+                                   :modules     {build-id {:entries [entry]}}
+                                   :build-hooks ['(watch/hook)]})))
                        {}
                        test-files)
         config (-> default-config
-                   (assoc :source-paths [integration-folder])
+                   (assoc :source-paths ["." integration-folder])
                    (assoc :builds builds)
                    (m/meta-merge (when (.existsSync fs override-config-path)
                                    (read-edn override-config-path))))]
@@ -103,6 +123,7 @@
                                   (.replace path (str integration-folder "/") ""))
         test-files              (->> (tree-seq :directory? read-dir (stat integration-folder))
                                      (keep :path)
+                                     (remove #(.startsWith % "#")) ;; Ignore Emacs temp files
                                      (filter #(.endsWith % ".cljs"))
                                      (map relative-to-integration))
         default-preprocessor    (browserify-preprocessor)
@@ -110,18 +131,23 @@
     (when-not (.existsSync fs working-directory)
       (.mkdirSync fs working-directory))
     (write-edn config-path config)
+    (.writeFileSync fs hook-path build-hook)
     (println "Starting shadow-cljs server")
-    (let [shadow-process (cp/spawn shadow-cljs-bin-path #js ["server"] #js {:cwd working-directory})
-          ready          (atom false)
-          output-fn      (fn [data]
-                           (let [s (buffer->str data)]
+    (let [shadow-process    (cp/spawn shadow-cljs-bin-path #js ["server"] #js {:cwd working-directory})
+          ready             (atom false)
+          socket            (atom nil)
+          output-fn         (fn [data]
+                              (let [s (buffer->str data)]
                              (when (.includes s "server version")
                                (reset! ready true))
                              (println (.trimEnd s))))
-          stopping       (atom false)
-          stop-fn        (fn []
+          stopping          (atom false)
+          build-poller      (atom nil)
+          stop-fn           (fn []
                            (when @stopping
                              (println "Stop in progress"))
+                           (js/clearInterval @build-poller)
+                           (.destroy ^node-net/Socket @socket)
                            (when-not @stopping
                              (reset! stopping true)
                              (println "Stopping shadow-cljs server")
@@ -129,7 +155,53 @@
                                (println "stdout:" (.trimEnd (buffer->str (.-stdout output))))
                                (println "stderr:" (.trimEnd (buffer->str (.-stderr output)))))
                              (println "Stopped shadow-cljs server")
-                             (process/exit 0)))]
+                             (process/exit 0)))
+          active-builds     (atom #{})
+          build-id->resolve (atom {})
+          build-id->rerun   (atom {})
+          build-id->file    (atom {})
+          deliver-now       (atom false)]
+      (add-watch ready :socket (fn []
+                                 (let [s (node-net/connect #js {:port    (js/parseInt (buffer->str (.readFileSync fs cli-repl-port-path)))
+                                                                :host    "localhost"
+                                                                :timeout 1000})]
+                                   (.on s "end" #(println "Control socket closed"))
+                                   (.on s "data" (fn [data]
+                                                   (let [string (buffer->str data)]
+                                                     (try
+                                                       (let [{:keys [event-id data] :as event} (edn/read-string string)]
+                                                         (println "Handling event" event-id)
+                                                         (case event-id
+                                                           :active-builds (do
+                                                                            (reset! active-builds data)
+                                                                            (println "active-builds:" data))
+                                                           :flush         (let [build-id data]
+                                                                            (when-let [resolve-fn (get @build-id->resolve build-id)]
+                                                                              (println "Delivering compile result")
+                                                                              (resolve-fn))
+                                                                            (when-let [rerun-fn (get @build-id->rerun build-id)]
+                                                                              (println "Compile done, rerunning test")
+                                                                              (rerun-fn))
+                                                                            (when-let [file (get @build-id->file build-id)]
+                                                                              (when (and (not (get @build-id->rerun build-id))
+                                                                                         (not (get @build-id->resolve build-id))
+                                                                                         (contains? @active-builds build-id))
+                                                                                (println "flush when no resolve present or rerun needed and shadow-cljs is watching" build-id ", triggering rerun to reload compilation result")
+                                                                                (reset! deliver-now true)
+                                                                                (.emit ^js file "rerun")))
+                                                                            (swap! build-id->resolve dissoc build-id)
+                                                                            (swap! build-id->rerun dissoc build-id))
+                                                           :error         (println "Error" data)
+                                                           (println "Unknown event" event)))
+                                                       (catch :default _
+                                                         (println "Failed to parse control message:" string))))))
+                                   (.write s "(require '[watch :as watch])\n (future (try (loop [] (println {:event-id :flush :data (.take watch/flush-queue)}) (recur)) (catch Throwable t (println {:event-id :error :data :flush-queue-read}))))\n")
+                                   (reset! build-poller (js/setInterval #(do
+                                                                           (.write s "(println {:event-id :active-builds :data (shadow/active-builds)})\n")
+                                                                           (println "build-id->resolve:" @build-id->resolve)
+                                                                           (println "build-id->rerun:" @build-id->rerun))
+                                                                        1000))
+                                   (reset! socket s))))
       ;; TODO: Option for compiling all tests at start
       #_(add-watch ready :compile (fn [_]
                                   (compile (map name (keys builds)))))
@@ -155,38 +227,50 @@
                   build-id      (keyword test-name)
                   test-file     (relative-to-integration filePath)
                   config        (read-edn config-path)]
+              (swap! build-id->file assoc build-id file)
               (when-not (contains? (:builds config) build-id)
                 (println (str "Adding build " build-id " to shadow-cljs configuration"))
                 (let [output-dir (str "out/" test-name)
-                      config     (update config :builds conj [build-id {:target           :browser
-                                                                        :output-dir       output-dir
-                                                                        :asset-path       (str "/" output-dir)
-                                                                        :modules          {build-id {:entries [(namespace-symbol test-file)]}}}])]
+                      config     (update config :builds conj [build-id {:target      :browser
+                                                                        :output-dir  output-dir
+                                                                        :asset-path  (str "/" output-dir)
+                                                                        :modules     {build-id {:entries [(namespace-symbol test-file)]}}
+                                                                        :build-hooks ['(watch/hook)]}])]
                   (write-edn config-path config)))
               (when (and (.-shouldWatch ^js file)
                          (not (contains? @watchers filePath)))
                 (println "Add watcher for" filePath)
                 (swap! watchers assoc filePath {:watcher       (let [watcher (chokidar/watch filePath)]
                                                                  (.on watcher "change" (fn [path]
-                                                                                         (println path "changed, recompiling")
-                                                                                         (-> (compile [(name build-id)])
-                                                                                             (.on "exit" (fn []
-                                                                                                           (.emit ^js file "rerun"))))))
+                                                                                         (swap! build-id->rerun assoc build-id #(.emit ^js file "rerun"))
+                                                                                         (if (contains? @active-builds build-id)
+                                                                                           (println path "is being watched shadow-cljs, skipping compile")
+                                                                                           (do
+                                                                                             (println path "changed, recompiling")
+                                                                                             (compile [(name build-id)])))))
                                                                  watcher)
                                                 :compiled-file compiled-file})
                 (.on ^EventEmitter file "close" (fn []
                                                   (println "Remove watcher for" filePath)
+                                                  (swap! build-id->file dissoc build-id)
                                                   (when-let [{:keys [watcher]} (get @watchers filePath)]
                                                     (.close watcher))
                                                   (swap! watchers dissoc filePath)
                                                   true)))
-              (js/Promise. (fn [resolve _reject]
-                             (println "Compiling" filePath)
-                             (let [compile-fn (fn []
-                                                (-> (compile [(name build-id)])
-                                                    (.on "exit" (fn [_]
-                                                                  (println "Compile done!" compiled-file)
-                                                                  (resolve compiled-file)))))]
-                               (if-not @ready
-                                 (add-watch ready :compile (fn [& _args] (compile-fn)))
-                                 (compile-fn))))))))))))
+              (js/Promise. (fn [resolve-fn _reject]
+                             (if @deliver-now
+                               (do
+                                 (println "Compilation result already present, delivering")
+                                 (reset! deliver-now false)
+                                 (resolve-fn compiled-file))
+                               (do
+                                 (swap! build-id->resolve assoc build-id #(resolve-fn compiled-file))
+                                 (let [compile-fn (fn []
+                                                    (if (contains? @active-builds build-id)
+                                                      (println "shadow-cljs watch active, skipping compile")
+                                                      (do
+                                                        (println "Compiling" filePath)
+                                                        (compile [(name build-id)]))))]
+                                   (if-not @ready
+                                     (add-watch ready :compile (fn [& _args] (compile-fn)))
+                                     (compile-fn))))))))))))))

--- a/src/net/tiuhti/utils.cljs
+++ b/src/net/tiuhti/utils.cljs
@@ -1,0 +1,33 @@
+(ns net.tiuhti.utils
+  (:require ["string_decoder" :as st]
+            ["fs" :as fs]
+            [clojure.edn :as edn]
+            [cljs.pprint :refer [pprint]]))
+
+(defn stat [dir]
+  (let [stat (.statSync fs dir)]
+    {:file-name dir
+     :directory? (.isDirectory stat)}))
+
+(defn read-dir [dir]
+  (let [parent (if (string? dir)
+                 (stat dir)
+                 dir)]
+    (map (fn [dirent]
+           {:file-name (.-name dirent)
+            :directory? (.isDirectory dirent)
+            :path (str (or (:path parent) (:file-name parent)) "/" (.-name dirent))})
+         (.readdirSync fs
+                       (or (:path parent) (:file-name parent))
+                       (clj->js {:withFileTypes true})))))
+
+(def decoder (st/StringDecoder. "utf8"))
+
+(defn buffer->str [buf]
+  (.write decoder buf))
+
+(defn write-edn [path content]
+  (.writeFileSync fs path (with-out-str (pprint content))))
+
+(defn read-edn [path]
+  (edn/read-string (buffer->str (.readFileSync fs path))))


### PR DESCRIPTION
Adds support for activating a ClojureScript repl in a test by running `(shadow/watch <build-id>)` && `(shadow/repl <build-id>)` through the shadow-cljs nrepl server.

Implementation is a bit iffy now, we detect if shadow-cljs watch is active by polling for `(shadow/active-builds)` via the cli-repl over a socket connection.

Also, these changes switch compilation result tracking from a simple exit handler on the `shadow-cljs compile` command to a [shadow-cljs build hook](https://shadow-cljs.github.io/docs/UsersGuide.html#build-hooks) in order to detect build changes of the shadow-cljs watch process. [`:flush`](https://shadow-cljs.github.io/docs/UsersGuide.html#compile-stages) events are put into a queue which is polled over the cli-repl by setting up a polling loop at startup. There's a bit of complexity on detecting the initial switch from a "normal" compilation result into a "watch" mode, since we trigger a rerun to make the browser load the extra js needed to make the cljs repl happen :) When ClojureScript repl is active, we kind of change from triggering build from a watch setup in the node process to tracking the flushes done by shadow-cljs.

